### PR TITLE
Info on what to do if `man command` fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ This #NICAR15 hands-on session aims to help beginners learn some basic commands 
 	* Now's a good time to introduce ```man``` or manual. Let's see what ```pwd``` does
 
 		```$ man pwd```
+	
+	* If you can't find help with ```man```, try ```info``` or add a ```-?``` or ```--help``` argument on the command
+
+		```$ info pwd```
+		```$ pwd -?```
+		```$ pwd --help```
 
 * [ls](http://www.compciv.org/unix-tools/#ls): list files in a specified directory
 


### PR DESCRIPTION
Adds `info` and the `-?` and `--help` args. The latter two don't work for `pwd`, but `pwd` outputs some help.
